### PR TITLE
Change bsm function signatures (closes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+Versioning Strategy
+-------------------
+Premia uses calendar versioning (CalVer).
+
+Releases follow the pattern:
+
+    YYYY.MM[.PATCH]
+
+• YYYY = release year
+• MM   = release month
+• PATCH (optional) = bugfix or minor enhancements within the month
+
+Breaking changes do NOT increment a separate version number.
+Instead, they are explicitly documented in the release notes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "premia"
-version = "2025.11"
+version = "2025.11.1"
 description = "Derivatives pricing"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/premia/black_scholes_merton.py
+++ b/src/premia/black_scholes_merton.py
@@ -4,9 +4,9 @@ parameter names to reduce user error.
 
 Function signatures:
 - option_type: 'c' (call) or 'p' (put)
-- spot: underlying spot price S
 - strike: strike price K
 - ttm: time to maturity in years
+- spot: underlying spot price S
 - vol: annualized volatility sigma
 - risk_free: annualized risk-free rate (continuously compounded)
 - dividend: annualized continuous dividend yield q (0.0 for classic Black–Scholes)
@@ -25,9 +25,9 @@ from py_vollib.black_scholes_merton.greeks.analytical import (
 
 def price(
     option_type: str,
-    spot: float,
     strike: float,
     ttm: float,
+    spot: float,
     vol: float,
     risk_free: float,
     dividend: float = 0.0,
@@ -38,9 +38,9 @@ def price(
 
 def delta(
     option_type: str,
-    spot: float,
     strike: float,
     ttm: float,
+    spot: float,
     vol: float,
     risk_free: float,
     dividend: float = 0.0,
@@ -51,9 +51,9 @@ def delta(
 
 def gamma(
     option_type: str,
-    spot: float,
     strike: float,
     ttm: float,
+    spot: float,
     vol: float,
     risk_free: float,
     dividend: float = 0.0,
@@ -64,9 +64,9 @@ def gamma(
 
 def theta(
     option_type: str,
-    spot: float,
     strike: float,
     ttm: float,
+    spot: float,
     vol: float,
     risk_free: float,
     dividend: float = 0.0,
@@ -77,9 +77,9 @@ def theta(
 
 def vega(
     option_type: str,
-    spot: float,
     strike: float,
     ttm: float,
+    spot: float,
     vol: float,
     risk_free: float,
     dividend: float = 0.0,
@@ -90,9 +90,9 @@ def vega(
 
 def rho(
     option_type: str,
-    spot: float,
     strike: float,
     ttm: float,
+    spot: float,
     vol: float,
     risk_free: float,
     dividend: float = 0.0,
@@ -113,9 +113,9 @@ _FUNCS = {
 
 def price_greeks(
     option_type: str,
-    spot: float,
     strike: float,
     ttm: float,
+    spot: float,
     vol: float,
     risk_free: float,
     dividend: float = 0.0,
@@ -130,7 +130,7 @@ def price_greeks(
         keys = list(which)
 
     return {
-        k: _FUNCS[k](option_type, spot, strike, ttm, vol, risk_free, dividend)
+        k: _FUNCS[k](option_type, strike, ttm, spot, vol, risk_free, dividend)
         for k in keys
     }
 
@@ -154,8 +154,8 @@ if __name__ == "__main__":
 
 
     # just price
-    print(price(option_type, spot, strike, ttm, vol, risk_free, dividend))
+    print(price(option_type, strike, ttm, spot, vol, risk_free, dividend))
     
-    res_greeks = price_greeks(option_type, spot, strike, ttm, vol, risk_free, dividend)
+    res_greeks = price_greeks(option_type, strike, ttm, spot, vol, risk_free, dividend)
     for ix_greek, ix_value in res_greeks.items():
         print(f"{ix_greek}: {ix_value}")

--- a/tests/test_black_scholes_merton.py
+++ b/tests/test_black_scholes_merton.py
@@ -12,7 +12,7 @@ def test_haug_put_value():
     dividend = 0.05
     
     value_reference = 2.4648
-    value_calc = price(option_type, spot, strike, ttm, vol, risk_free, dividend)
+    value_calc = price(option_type, strike, ttm, spot,vol, risk_free, dividend)
     assert abs(value_reference - value_calc) < 0.0001
 
 def test_haug_short_dated_call():
@@ -24,7 +24,7 @@ def test_haug_short_dated_call():
     risk_free = 0.08
     dividend = 0
 
-    res_greeks = price_greeks(option_type, spot, strike, ttm, vol, risk_free, dividend)
+    res_greeks = price_greeks(option_type,  strike, ttm, spot, vol, risk_free, dividend)
     assert abs(res_greeks["price"] - 2.1333684449) < 0.000001
     assert abs(res_greeks["delta"] - 0.3724827980) < 0.000001 
     assert abs(res_greeks["gamma"] - 0.0420427558) < 0.000001
@@ -42,7 +42,7 @@ def test_greeks_r_package_call_values():
     risk_free = 0.01
     dividend = 0
 
-    res_greeks = price_greeks(option_type, spot, strike, ttm, vol, risk_free, dividend)
+    res_greeks = price_greeks(option_type, strike, ttm, spot, vol, risk_free, dividend)
     assert abs(res_greeks["price"] - 21.577149923) < 0.000001
     assert abs(res_greeks["delta"] - 0.554941778) < 0.000001 
     assert abs(res_greeks["gamma"] - 0.005890593) < 0.000001
@@ -60,7 +60,7 @@ def test_odengard_call_values():
     risk_free = 0.1
     dividend = 0
 
-    res_greeks = price_greeks(option_type, spot, strike, ttm, vol, risk_free, dividend)
+    res_greeks = price_greeks(option_type, strike, ttm, spot, vol, risk_free, dividend)
     assert abs(res_greeks["price"] - 5.4532499260) < 0.000001
     assert abs(res_greeks["delta"] - 0.6337373578) < 0.000001 
     assert abs(res_greeks["gamma"] - 0.0354788717) < 0.000001
@@ -77,8 +77,8 @@ def test_odengard_put_and_call_values():
     risk_free = 0.10
     dividend = 0
 
-    call_greeks = price_greeks("c", spot, strike, ttm, vol, risk_free, dividend)
-    put_greeks = price_greeks("p", spot, strike, ttm, vol, risk_free, dividend)
+    call_greeks = price_greeks("c", strike, ttm, spot, vol, risk_free, dividend)
+    put_greeks = price_greeks("p", strike, ttm, spot,vol, risk_free, dividend)
     
     # call values
     assert abs(call_greeks["price"] - 14.9757907783) < 0.000001


### PR DESCRIPTION
I changed all the black-scholes-merton function signatures:

FROM: (option_type, spot, strike, ttm, vol, risk_free, dividend)
TO: (option_type, strike, ttm, spot, vol, risk_free, dividend)

This moves all the contract specifications to the beginning of the function signature, and all the market-inputs to the then of the function signature.  Also, for both categories, the ordering is from most impactful to least impactful on the price of the option.

The hope is that this makes the function signatures easier to remember.